### PR TITLE
Cleanup rspec deprecations

### DIFF
--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -4,20 +4,20 @@ describe Gem::ConfigFile do
   before do
     @credentials = File.dirname(__FILE__) + '/../test_credentials'
     @config = Gem::ConfigFile.new([])
-    @config.stub(:credentials_path) { @credentials }
+    allow(@config).to receive(:credentials_path) { @credentials }
   end
 
   describe "#api_keys" do
     it "should load from credentials file" do
       credentials = {:personal => '1'*32, :work => '2'*32}
       File.open(@credentials, 'w') { |f| f.write credentials.to_yaml }
-      @config.api_keys.should == credentials
+      expect(@config.api_keys).to eq(credentials)
     end
 
     it "should add existing rubygems key to the hash" do
       credentials = {:rubygems_api_key => '0'*32}
       File.open(@credentials, 'w') { |f| f.write credentials.to_yaml }
-      @config.api_keys.should == {:rubygems => '0'*32}
+      expect(@config.api_keys).to eq({:rubygems => '0'*32})
     end
   end
 
@@ -27,7 +27,7 @@ describe Gem::ConfigFile do
       accounts = {:personal => '1'*32, :work => '2'*32}
       @config.api_keys = accounts
 
-      File.read(@credentials).should == accounts.to_yaml
+      expect(File.read(@credentials)).to eq(accounts.to_yaml)
     end
 
     it "should preserve existing credentials" do
@@ -35,7 +35,7 @@ describe Gem::ConfigFile do
       @config.api_keys = {:personal => '1'*32, :work => '2'*32}
 
       credentials = YAML.load_file(@credentials)
-      credentials[:rubygems_api_key].should == '0'*32
+      expect(credentials[:rubygems_api_key]).to eq('0'*32)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,3 +2,7 @@ $:.unshift(File.dirname(__FILE__) + '/../../lib')
 
 require 'rspec/mocks'
 require 'keycutter'
+
+# Set permissions to what rubygems wants,
+# so it doesn't throw a permissions error
+File.chmod(0600, 'test_credentials')


### PR DESCRIPTION
This PR cleans up the tests that are run with `rake spec`.

- Sets the file permissions on the example `test_credentials` file to align with what rubygems wants the permissions to be- 0600
- Upgrades the expectation and stub api to the new API because the old has been deprecated

**before**:
```
$ rake spec
/Users/cmcelligott/.rvm/rubies/ruby-2.3.3/bin/ruby -I/Users/cmcelligott/.rvm/gems/ruby-2.3.3/gems/rspec-core-3.5.4/lib:/Users/cmcelligott/.rvm/gems/ruby-2.3.3/gems/rspec-support-3.5.0/lib /Users/cmcelligott/.rvm/gems/ruby-2.3.3/gems/rspec-core-3.5.4/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb --color --format progress
...ERROR:  Your gem push credentials file located at:

        /Users/cmcelligott/src/keycutter/spec/../test_credentials

has file permissions of 0644 but 0600 is required.

To fix this error run:

        chmod 0600 /Users/cmcelligott/src/keycutter/spec/../test_credentials

You should reset your credentials at:

        https://rubygems.org/profile/edit

if you believe they were disclosed to a third party.


Deprecation Warnings:

Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /Users/cmcelligott/src/keycutter/spec/configuration_spec.rb:14:in `block (3 levels) in <top (required)>'.

Using `stub` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /Users/cmcelligott/src/keycutter/spec/configuration_spec.rb:7:in `block (2 levels) in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

2 deprecation warnings total

Finished in 0.02988 seconds (files took 0.07666 seconds to load)
4 examples, 0 failures
```

**after**:
```
$ rake spec
/Users/cmcelligott/.rvm/rubies/ruby-2.3.3/bin/ruby -I/Users/cmcelligott/.rvm/gems/ruby-2.3.3/gems/rspec-core-3.5.4/lib:/Users/cmcelligott/.rvm/gems/ruby-2.3.3/gems/rspec-support-3.5.0/lib /Users/cmcelligott/.rvm/gems/ruby-2.3.3/gems/rspec-core-3.5.4/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb --color --format progress
....

Finished in 0.03479 seconds (files took 0.07853 seconds to load)
4 examples, 0 failures
```