### PR TITLE
Fix tests and bugs

### DIFF
--- a/features/add.feature
+++ b/features/add.feature
@@ -5,7 +5,7 @@ Feature: Adding keys
 
   Scenario Outline: Adding a new key
     Given a valid gemcutter account
-    When I run "gem keys <command> <key>" interactively
+    When I run `gem keys <command> <key>` interactively
     And I type "josh@vitamin-j.com"
     And I type "12345"
     Then the output should contain "Added <key> API key"
@@ -19,7 +19,7 @@ Feature: Adding keys
 
   Scenario: Adding a key with bad credentials
     Given an invalid gemcutter account
-    When I run "gem keys -a bogus" interactively
+    When I run `gem keys -a bogus` interactively
     And I type "josh@vitamin-j.com"
     And I type "12345"
     Then the output should contain "Access denied"
@@ -29,7 +29,7 @@ Feature: Adding keys
   Scenario: Adding a key from a compatible host
     Given a gemcutter host at "https://nubygems.org"
     And a valid gemcutter account
-    When I run "gem keys --add personal --host https://nubygems.org" interactively
+    When I run `gem keys --add personal --host https://nubygems.org` interactively
     And I type "josh@vitamin-j.com"
     And I type "12345"
     Then the output should contain "Enter your nubygems.org credentials"

--- a/features/default.feature
+++ b/features/default.feature
@@ -11,7 +11,7 @@ Feature: Using gem keys
 
   Scenario Outline: Using a different key
     Given my current rubygems key is "work"
-    When I run "gem keys <command> <key>"
+    When I run `gem keys <command> <key>`
     Then the output should contain "Now using <key> API key"
     And my current rubygems key should be "<key>"
 
@@ -23,7 +23,7 @@ Feature: Using gem keys
 
   Scenario: Using a bogus key
     Given my current rubygems key is "personal"
-    When I run "gem keys -d bogus"
+    When I run `gem keys -d bogus`
     Then the output should contain "No such API key. You can add it with: gem keys -a bogus"
     And the exit status should be 1
     And my current rubygems key should be "personal"

--- a/features/list.feature
+++ b/features/list.feature
@@ -4,7 +4,7 @@ Feature: Default commands
   So I can put keycutter to best use
 
   Scenario: Installing the gem
-    When I run "gem q"
+    When I run `gem q`
     Then the output should contain "keycutter"
 
   Scenario: Calling the plugin with no options
@@ -15,7 +15,7 @@ Feature: Default commands
       |oss_1   |33333333333333333333333333333333|
       |oss_2   |44444444444444444444444444444444|
     And my current rubygems key is "rubygems"
-    When I run "gem keys"
+    When I run `gem keys`
     Then the output should contain:
     """
     *** CURRENT KEYS ***
@@ -32,7 +32,7 @@ Feature: Default commands
       |rubygems|11111111111111111111111111111111|
       |work    |22222222222222222222222222222222|
     And my current rubygems key is "work"
-    When I run "gem keys <option>"
+    When I run `gem keys <option>`
     Then the output should contain:
     """
     *** CURRENT KEYS ***

--- a/features/remove.feature
+++ b/features/remove.feature
@@ -10,7 +10,7 @@ Feature: Remove API keys
       |work    |22222222222222222222222222222222|
 
   Scenario Outline:
-    When I run "gem keys <command> <key>"
+    When I run `gem keys <command> <key>`
     Then the output should contain "Removed <key> API key"
     And I should not have a "<key>" api key
 
@@ -20,5 +20,5 @@ Feature: Remove API keys
       |--remove|work    |
 
   Scenario: Removing a bogus key
-    When I run "gem keys -r bogus"
+    When I run `gem keys -r bogus`
     Then the output should contain "No such API key"

--- a/features/step_definitions/keycutter_steps.rb
+++ b/features/step_definitions/keycutter_steps.rb
@@ -29,20 +29,20 @@ end
 
 Then /^my current rubygems key should be "([^"]*)"$/ do |key|
   Gem.configuration.load_rubygems_api_key
-  Gem.configuration.rubygems_api_key.should == Gem.configuration.api_keys[key.to_sym]
+  expect(Gem.configuration.rubygems_api_key).to eq(Gem.configuration.api_keys[key.to_sym])
 end
 
 Then /^I should have a "([^"]*)" api key$/ do |key|
   Gem.configuration.load_api_keys
-  Gem.configuration.api_keys.should have_key(key.to_sym)
+  expect(Gem.configuration.api_keys).to have_key(key.to_sym)
 end
 
 Then /^I should not have a "([^"]*)" api key$/ do |key|
   Gem.configuration.load_api_keys
-  Gem.configuration.api_keys.should_not have_key(key.to_sym)
+  expect(Gem.configuration.api_keys).not_to have_key(key.to_sym)
 end
 
 Then /^the "([^"]*)" api key should be the response body$/ do |key|
   Gem.configuration.load_api_keys
-  Gem.configuration.api_keys[key.to_sym].should == ENV['FAKEWEB_BODY']
+  expect(Gem.configuration.api_keys[key.to_sym]).to eq(ENV['FAKEWEB_BODY'])
 end

--- a/features/step_definitions/keycutter_steps.rb
+++ b/features/step_definitions/keycutter_steps.rb
@@ -26,9 +26,8 @@ Given /^a gemcutter host at "([^"]*)"$/ do |host|
   set_env 'FAKEWEB_HOST', host
 end
 
-
 Then /^my current rubygems key should be "([^"]*)"$/ do |key|
-  Gem.configuration.load_rubygems_api_key
+  Gem.configuration.load_api_keys
   expect(Gem.configuration.rubygems_api_key).to eq(Gem.configuration.api_keys[key.to_sym])
 end
 

--- a/lib/keycutter/configuration.rb
+++ b/lib/keycutter/configuration.rb
@@ -13,7 +13,7 @@ class Gem::ConfigFile
 
     require 'yaml'
 
-    File.open(credentials_path, 'w') do |f|
+    File.open(credentials_path, 'w', 0600) do |f|
       f.write keys.to_yaml
     end
 
@@ -21,10 +21,10 @@ class Gem::ConfigFile
   end
 
   def load_api_keys
-    @api_keys = File.exists?(credentials_path) ? load_file(credentials_path) : @hash
+    @api_keys = File.exists?(credentials_path) ? load_file(credentials_path) : {}
     if @api_keys.key?(:rubygems_api_key)
-      rubygems_api_key = @api_keys.delete(:rubygems_api_key)
-      @api_keys[:rubygems] = rubygems_api_key unless @api_keys.key?(:rubygems)
+      @rubygems_api_key = @api_keys.delete(:rubygems_api_key)
+      @api_keys[:rubygems] = @rubygems_api_key unless @api_keys.key?(:rubygems)
     end
     @api_keys
   end


### PR DESCRIPTION
This PR fixes #3, fixes #4, and fixes #5, as well as fixes the Cucumber tests and updates most of the deprecations in that test suite. With this PR, all tests now pass, and the gem functions as advertised with Rubygems 2.4.8 and Ruby 2.1.2/2.3.3.

There's still a deprecation warning in the Cucumber suite about migrating from `set_env` => `set_environment_variable`, but the two methods have different behavior and I couldn't figure out how `set_environment_variable` worked. 

