### PR TITLE
Change Gem::RubyGemsVersion to Gem::VERSION

### DIFF
--- a/lib/rubygems/commands/keys_command.rb
+++ b/lib/rubygems/commands/keys_command.rb
@@ -26,7 +26,7 @@ class Gem::Commands::KeysCommand < Gem::Command
       options[:add] = value
     end
 
-    if Gem::Version.new(Gem::RubyGemsVersion) >= Gem::Version.new('1.4.0')
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.4.0')
       add_option '--host HOST', 'Use another gemcutter-compatible host' do |value,options|
         options[:host] = value
       end
@@ -51,7 +51,7 @@ class Gem::Commands::KeysCommand < Gem::Command
     options[:list] = !(options[:default] || options[:remove] || options[:add])
 
     if options[:add] then
-      if Gem::Version.new(Gem::RubyGemsVersion) >= Gem::Version.new('1.4.0')
+      if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.4.0')
         gem_host = URI.parse(options[:host] || Gem.host).host
       else
         gem_host = 'Rubygems.org'

--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -1,6 +1,6 @@
 require 'rubygems/command_manager'
 
-if Gem::Version.new(Gem::RubyGemsVersion) >= Gem::Version.new('1.3.6')
+if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.3.6')
   Gem::CommandManager.instance.register_command :keys
 end
 


### PR DESCRIPTION
This PR changes the name of a constant used in checking the currently used RubyGems version.

  - this avoids a deprecation introduced in https://github.com/rubygems/rubygems/pull/2857

(There are failures in running the tests, which are about `NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement.` - ~PR coming~ see https://github.com/joshfrench/keycutter/pull/9 )