### PR TITLE
Drop removed spec property rubyforge_project

### DIFF
--- a/keycutter.gemspec
+++ b/keycutter.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Gemcutter key management}
   s.description = %q{Multiple gemcutter accounts? Manage your keys with ease.}
 
-  s.rubyforge_project = "keycutter"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {spec,features}/*`.split("\n")
   s.require_paths = ["lib"]


### PR DESCRIPTION
The RubyGems gemspec property rubyforge_project has been removed without a replacement.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436